### PR TITLE
Update cncf-netlify-starter dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,3 @@ command = "make preview-build"
 
 [context.branch-deploy]
 command = "make preview-build"
-
-[[plugins]]
-package = "netlify-plugin-checklinks"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.60.0"
+HUGO_VERSION = "0.73.0"
 
 [context.deploy-preview]
 command = "make preview-build"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bulma": "^0.8.0"
+    "bulma": "^0.9.0"
   }
 }


### PR DESCRIPTION
And remove the netlify linkchecker – it crashes builds in repos that use this as a template, because the plugin isn't configured on new Netlify deploys by default.