### PR TITLE
Adding labels to .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -56,7 +56,7 @@ labels:
   - name: e0-minutes
     description: "Effort: < 60 min"
     color: e6ccb3
-  # Default new repo labels
+  # GitHub default labels
   - name: bug
     description: "Something isn't working"
     color: d73a4a

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,3 +26,62 @@ collaborators:
     permission: admin
   - username: kapunahelewong
     permission: admin
+
+# Labels: define labels for Issues and Pull Requests
+labels:
+  - name: cleanup
+    color: 1ebcd8
+  - name: e1-hours
+    description: "Effort: < 8 hrs"
+    color: d9b38c
+  - name: e2-days
+    description: "Effort: < 5 days"
+    color: cc9966
+  - name: e3-weeks
+    description: "Effort: < 4 weeks"
+    color: bf8040
+  - name: e4-months
+    description: "Effort: 1+ months"
+    color: 996633
+  - name: infrastructure
+    color: 696969
+  - name: p0-critical
+    color: B60205
+  - name: p1-high
+    color: D93F0B
+  - name: p2-medium
+    color: FBCA04
+  - name: p3-low
+    color: FEF2C0
+  - name: e0-minutes
+    description: "Effort: < 60 min"
+    color: e6ccb3
+  # Default new repo labels
+  - name: bug
+    description: "Something isn't working"
+    color: d73a4a
+  - name: documentation
+    description: Improvements or additions to documentation
+    color: 0075ca
+  - name: duplicate
+    description: This issue or pull request already exists
+    color: cfd3d7
+  - name: enhancement
+    description: New feature or request
+    color: a2eeef
+  - name: good first issue
+    description: Good for newcomers
+    color: 7057ff
+  - name: help wanted
+    description: Extra attention is needed
+    color: 008672
+  - name: invalid
+    description: "This doesn't seem right"
+    color: e4e669
+  - name: question
+    description: Further information is requested
+    color: d876e3
+  - name: wontfix
+    description: This will not be worked on
+    color: ffffff
+


### PR DESCRIPTION
Fixes #79

**Note**: Adding labels this way will remove labels already added via the GitHub UI.

In case GitHub isn't able to reapply labels when merging this PR, this is how they are currently applied (to _open_ issues/PRs):

bug: #56, #52, #45
cleanup: #85 
documentation: #29, #24, #23, #22
enhancement: #83, #80, #28, #27, #26, #25, #21, #20, #19, #18
infrastructure: #85, #83, #79, #68
question: #76, #87