### PR TITLE
css.html template cleanup

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,14 +1,14 @@
-{{- $inServerMode := site.IsServer }}
-{{- $includePaths := (slice "node_modules") }}
-{{- $sass         := "sass/custom.sass" }}
-{{- $cssOutput    := "css/style.css" }}
-{{- $devOpts      := (dict "targetPath" $cssOutput "includePaths" $includePaths "enableSourceMap" true) }}
-{{- $prodOpts     := (dict "targetPath" $cssOutput "includePaths" $includePaths "outputStyle" "compressed") }}
-{{- $cssOpts      := cond $inServerMode $devOpts $prodOpts }}
-{{- $css          := resources.Get $sass | resources.ExecuteAsTemplate "blah.sass" . | toCSS $cssOpts }}
-{{- if $inServerMode }}
+{{ $inServerMode := site.IsServer -}}
+{{ $includePaths := (slice "node_modules") -}}
+{{ $sass         := "sass/custom.sass" -}}
+{{ $cssOutput    := "css/style.css" -}}
+{{ $devOpts      := (dict "targetPath" $cssOutput "includePaths" $includePaths "enableSourceMap" true) -}}
+{{ $prodOpts     := (dict "targetPath" $cssOutput "includePaths" $includePaths "outputStyle" "compressed") -}}
+{{ $cssOpts      := cond $inServerMode $devOpts $prodOpts -}}
+{{ $css          := resources.Get $sass | resources.ExecuteAsTemplate "blah.sass" . | toCSS $cssOpts -}}
+{{ if $inServerMode -}}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
-{{- else }}
-{{- $prodCss      := $css | fingerprint }}
+{{ else -}}
+{{ $prodCss      := $css | fingerprint -}}
 <link rel="stylesheet" href="{{ $prodCss.RelPermalink }}" integrity="{{ $prodCss.Data.Integrity }}">
-{{- end }}
+{{ end -}}


### PR DESCRIPTION
There is no change in the generated site, I just moved the whitespace-trim marker from the front to the end of the template directives syntax. I'm doing this cleanup so that followup changes will be easier to see.

Signed-off-by: Patrice Chalin <pchalin@gmail.com>