### PR TITLE
fix white space around links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,10 +1,16 @@
-{{ $link := .Destination }}
-{{ $isRemote := strings.HasPrefix $link "http" }}
-{{- if not $isRemote -}}
-{{ $url := urls.Parse .Destination }}
-{{- if $url.Path -}}
-{{ $fragment := "" }}
-{{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
-{{- if .Page.GetPage $url.Path }}{{ $link = printf "%s%s" (.Page.GetPage $url.Path).RelPermalink $fragment }}{{ end }}{{ end -}}
-{{- end -}}
-<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}{{ if $isRemote }} <sup><i class="fas fa-external-link-alt"></i></sup>{{ end }}</a>
+{{ $link := .Destination -}}
+{{ $isRemote := strings.HasPrefix $link "http" -}}
+{{ if not $isRemote -}}
+  {{ $url := urls.Parse .Destination -}}
+  {{ if $url.Path -}}
+    {{ $fragment := "" -}}
+    {{ with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+    {{ with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end -}}
+  {{ end -}}
+{{ end -}}
+<a href="{{ $link | safeURL }}"
+  {{- with .Title}} title="{{ . }}"{{ end -}}
+  {{- if $isRemote }} target="_blank" rel="noopener"{{ end -}}
+>
+{{- .Text | safeHTML -}}
+</a>


### PR DESCRIPTION
This PR is a work in progress trying to fix the extra space that appears around links:

<img width="100" alt="Screen Shot 2021-07-26 at 10 08 47 AM" src="https://user-images.githubusercontent.com/4116963/127002765-943e0f91-4a17-4649-a93a-94a68b7c4cbd.png">
