### PR TITLE
Render links with given destination w/o rewriting

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,16 +1,7 @@
-{{ $link := .Destination -}}
-{{ $isRemote := strings.HasPrefix $link "http" -}}
-{{ if not $isRemote -}}
-  {{ $url := urls.Parse .Destination -}}
-  {{ if $url.Path -}}
-    {{ $fragment := "" -}}
-    {{ with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
-    {{ with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end -}}
-  {{ end -}}
-{{ end -}}
-<a href="{{ $link | safeURL }}"
+{{ $isExternal := hasPrefix .Destination "http" -}}
+<a href="{{ .Destination | safeURL }}"
   {{- with .Title}} title="{{ . }}"{{ end -}}
-  {{- if $isRemote }} target="_blank" rel="noopener"{{ end -}}
+  {{- if $isExternal }} target="_blank" rel="noopener"{{ end -}}
 >
 {{- .Text | safeHTML -}}
 </a>


### PR DESCRIPTION
- Closes #77 
- There is no change in the generated site.

Preview illustrating that this change hasn't introduced any regressions regarding whitespace: https://deploy-preview-98--cncf-hugo-starter.netlify.app/docs/demo/#images