### PR TITLE
NPM scripts for site CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ strictly required.
 
 The starter uses the following:
 
-* **[Hugo (extended, v0.73 or above)](https://gohugo.io/)** as a static site
-  generator
+* **[Hugo](https://gohugo.io/)** as a static site generator
 * **[Bootstrap 4.5.x](https://getbootstrap.com/docs/4.5/getting-started/introduction/)** as a CSS framework
 * **[Netlify](https://www.netlify.com/)** for building, hosting, and DNS management
 
@@ -22,7 +21,7 @@ repository and run the following two commands in its directory:
 npm install
 
 # Run the server locally
-make serve
+npm run serve
 ```
 
 ## Running on Netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
 publish = "public"
-command = "make production-build"
+command = "npm run build:production"
 
 [context.deploy-preview]
-command = "make preview-build"
+command = "npm run build:preview"
 
 [context.branch-deploy]
-command = "make preview-build"
+command = "npm run build:preview"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,18 @@
 {
+  "scripts": {
+    "build-and-serve": "npm run build && npm run serve",
+    "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL $DEPLOY_PRIME_URL",
+    "build:production": "hugo --cleanDestinationDir --minify",
+    "build": "hugo --cleanDestinationDir -e dev -DFE",
+    "hugo:version": "hugo version",
+    "serve": "netlify dev -c \"hugo serve -DFE --minify -w\""
+  },
   "devDependencies": {
-    "bootstrap": "^4.5.2",
     "@fortawesome/fontawesome-free": "^5.14.0",
-    "hugo-extended": "^0.85.0",
+    "bootstrap": "^4.5.2",
+    "hugo-extended": "^0.86.0",
     "jquery": "^3.5.1",
+    "netlify-cli": "^5.2.10",
     "popper.js": "^1.16.1"
   }
 }


### PR DESCRIPTION
Notes:

- Added `netlify-cli` for `serve` script.
- Minimal edits done to README. More to come in the scope of another PR.
- I'm choosing to leave the Makefile for now. We can discuss this during our design meeting later today. Related: #103

**Note** that to use another version of Hugo, one has to `npm uninstall hugo-extended`.

cc @kapunahelewong 

Signed-off-by: Patrice Chalin <pchalin@gmail.com>