### PR TITLE
Support running build:preview locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build-and-serve": "npm run build && npm run serve",
-    "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL $DEPLOY_PRIME_URL",
+    "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "hugo --cleanDestinationDir -e dev -DFE",
     "hugo:version": "hugo version",


### PR DESCRIPTION
Add a default value for `DEPLOY_PRIME_URL` (which isn't set when we run locally) -- otherwise the script just fails.