### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # npm assets
 node_modules/
 package-lock.json
+
+# ignore system files
+.DS_Store


### PR DESCRIPTION
Signed-off-by: Kapunahele Wong <kapunahelewong@gmail.com>

Adding `.DS_Store` to `.gitignore` so that if a user with a mac browses the starter in the Finder, git will ignore the OS-generated `.DS_Store`.