### PR TITLE
Add the responsive viewport meta tag

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -12,3 +12,4 @@
 {{ else -}}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 {{ end -}}
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Based on work by @di in the private repo https://github.com/securitysos/sos.dev (https://github.com/securitysos/sos.dev/pull/21 & https://github.com/securitysos/sos.dev/pull/22 -- since https://sos.dev is live now, I think it's OK to link to the repo)

deploy preview: https://deploy-preview-111--cncf-hugo-starter.netlify.app/

fixes #56 